### PR TITLE
feat: add blog detail page

### DIFF
--- a/frontend/components/blog-list.tsx
+++ b/frontend/components/blog-list.tsx
@@ -6,7 +6,7 @@ export interface BlogListProps {
 }
 
 export interface BlogPost {
-  id: string,
+  id: string;
   header: string;
   description: string;
   date: string;
@@ -23,7 +23,11 @@ export const BlogList = (props: BlogListProps) => {
             return (
               <List.Item key={index}>
                 <div className={index ? "mt-8" : ""}>
-                  <Link href={`/blog/${item.id}`}><Text className="text-2xl" component="a">{item.header}</Text></Link>
+                  <Link href={`/blog/${item.id}`}>
+                    <Text className="text-2xl" component="a">
+                      {item.header}
+                    </Text>
+                  </Link>
                   <Text className="mt-4 text-base" lineClamp={2}>
                     {item.description}
                   </Text>

--- a/frontend/components/blog-list.tsx
+++ b/frontend/components/blog-list.tsx
@@ -1,10 +1,12 @@
 import { List, Text } from "@mantine/core";
+import Link from "next/link";
 
 export interface BlogListProps {
   blogPosts: BlogPost[];
 }
 
 export interface BlogPost {
+  id: string,
   header: string;
   description: string;
   date: string;
@@ -21,7 +23,7 @@ export const BlogList = (props: BlogListProps) => {
             return (
               <List.Item key={index}>
                 <div className={index ? "mt-8" : ""}>
-                  <Text className="text-2xl">{item.header}</Text>
+                  <Link href={`/blog/${item.id}`}><Text className="text-2xl" component="a">{item.header}</Text></Link>
                   <Text className="mt-4 text-base" lineClamp={2}>
                     {item.description}
                   </Text>

--- a/frontend/components/header-menu-overlay.tsx
+++ b/frontend/components/header-menu-overlay.tsx
@@ -39,7 +39,9 @@ export const HeaderMenuOverlay = ({
                   }}
                   key={index}
                 >
-                  <Link href={item.href}><a>{item.text}</a></Link>
+                  <Link href={item.href}>
+                    <a>{item.text}</a>
+                  </Link>
                 </List.Item>
               );
             })}

--- a/frontend/components/header-menu-overlay.tsx
+++ b/frontend/components/header-menu-overlay.tsx
@@ -39,7 +39,7 @@ export const HeaderMenuOverlay = ({
                   }}
                   key={index}
                 >
-                  <Link href={item.href}>{item.text}</Link>
+                  <Link href={item.href}><a>{item.text}</a></Link>
                 </List.Item>
               );
             })}

--- a/frontend/components/simple-headline-and-title-section.tsx
+++ b/frontend/components/simple-headline-and-title-section.tsx
@@ -10,7 +10,7 @@ export const SimpleHeadlineAndTitleSection = ({
 }) => {
   return (
     <div className="w-full">
-      <Text className="text-3xl font-bold border-b border-m_gray-2 pb-6">
+      <Text className="text-3xl font-bold border-0 border-b border-m_gray-2 border-solid pb-6">
         {headline}
       </Text>
       <div className="mt-8">{children}</div>

--- a/frontend/lib/dummy-blog-posts-state.ts
+++ b/frontend/lib/dummy-blog-posts-state.ts
@@ -2,21 +2,25 @@ import { BlogPost } from "../components/blog-list";
 import { Dispatch, SetStateAction, useState } from "react";
 
 export const useDummyBlogPostsState = (): DummyBlogPostsState => {
-  const [blogPosts, setBlogPosts] = useState(dummyBlogPosts.slice(0,5));
+  const [blogPosts, setBlogPosts] = useState(dummyBlogPosts.slice(0, 5));
   return new DummyBlogPostsState(blogPosts, setBlogPosts);
 };
 
 class DummyBlogPostsState {
   readonly blogPosts: BlogPost[];
   private readonly setBlogPosts: Dispatch<
-    SetStateAction<{ id: string, header: string; description: string; date: string }[]>
-    >;
+    SetStateAction<
+      { id: string; header: string; description: string; date: string }[]
+    >
+  >;
 
   constructor(
     blogPosts: BlogPost[],
     setBlogPosts: Dispatch<
-      SetStateAction<{ id: string, header: string; description: string; date: string }[]>
+      SetStateAction<
+        { id: string; header: string; description: string; date: string }[]
       >
+    >
   ) {
     this.blogPosts = blogPosts;
     this.setBlogPosts = setBlogPosts;
@@ -24,7 +28,7 @@ class DummyBlogPostsState {
 
   async loadMorePosts() {
     await delay(3000);
-    this.setBlogPosts(dummyBlogPosts.slice(0,this.blogPosts.length + 5));
+    this.setBlogPosts(dummyBlogPosts.slice(0, this.blogPosts.length + 5));
     return { moreDataYet: this.blogPosts.length < 10 };
   }
 }
@@ -33,11 +37,9 @@ const delay = async (ms: number) => {
   return new Promise((resolve) => setTimeout(resolve, ms));
 };
 
-export const dummyBlogPosts: BlogPost[] =
-  [...Array(50)].map((_, index) => ({
-    id: `QWERTYUI-${index}`,
-    header: `index ${index} page`,
-    description:
-      `Amet minim mollit non deserunt ullamco est sit aliqua dolor do amet sint. Velit officia consequat duis enim velit mollit.`,
-    date: "2022.07.11",
-  }));
+export const dummyBlogPosts: BlogPost[] = [...Array(50)].map((_, index) => ({
+  id: `QWERTYUI-${index}`,
+  header: `index ${index} page`,
+  description: `Amet minim mollit non deserunt ullamco est sit aliqua dolor do amet sint. Velit officia consequat duis enim velit mollit.`,
+  date: "2022.07.11",
+}));

--- a/frontend/lib/dummy-blog-posts-state.ts
+++ b/frontend/lib/dummy-blog-posts-state.ts
@@ -2,21 +2,21 @@ import { BlogPost } from "../components/blog-list";
 import { Dispatch, SetStateAction, useState } from "react";
 
 export const useDummyBlogPostsState = (): DummyBlogPostsState => {
-  const [blogPosts, setBlogPosts] = useState(createDummyPosts());
+  const [blogPosts, setBlogPosts] = useState(dummyBlogPosts.slice(0,5));
   return new DummyBlogPostsState(blogPosts, setBlogPosts);
 };
 
 class DummyBlogPostsState {
   readonly blogPosts: BlogPost[];
   private readonly setBlogPosts: Dispatch<
-    SetStateAction<{ header: string; description: string; date: string }[]>
-  >;
+    SetStateAction<{ id: string, header: string; description: string; date: string }[]>
+    >;
 
   constructor(
     blogPosts: BlogPost[],
     setBlogPosts: Dispatch<
-      SetStateAction<{ header: string; description: string; date: string }[]>
-    >
+      SetStateAction<{ id: string, header: string; description: string; date: string }[]>
+      >
   ) {
     this.blogPosts = blogPosts;
     this.setBlogPosts = setBlogPosts;
@@ -24,8 +24,7 @@ class DummyBlogPostsState {
 
   async loadMorePosts() {
     await delay(3000);
-    const moreBlogPosts = createDummyPosts();
-    this.setBlogPosts([...this.blogPosts, ...moreBlogPosts]);
+    this.setBlogPosts(dummyBlogPosts.slice(0,this.blogPosts.length + 5));
     return { moreDataYet: this.blogPosts.length < 10 };
   }
 }
@@ -34,10 +33,11 @@ const delay = async (ms: number) => {
   return new Promise((resolve) => setTimeout(resolve, ms));
 };
 
-const createDummyPosts = () =>
-  [...Array(5)].map((_) => ({
-    header: "This is a header",
+export const dummyBlogPosts: BlogPost[] =
+  [...Array(50)].map((_, index) => ({
+    id: `QWERTYUI-${index}`,
+    header: `index ${index} page`,
     description:
-      "Amet minim mollit non deserunt ullamco est sit aliqua dolor do amet sint. Velit officia consequat duis enim velit mollit.",
+      `Amet minim mollit non deserunt ullamco est sit aliqua dolor do amet sint. Velit officia consequat duis enim velit mollit.`,
     date: "2022.07.11",
   }));

--- a/frontend/pages/blog/[slug].tsx
+++ b/frontend/pages/blog/[slug].tsx
@@ -1,0 +1,47 @@
+import Head from "next/head";
+import PaddingXWrapper from "../../components/padding-x-wrapper";
+import SimpleHeadlineAndTitleSection from "../../components/simple-headline-and-title-section";
+import {BlogPost as BlogPostData} from "../../components/blog-list";
+import {GetStaticPaths, GetStaticProps} from "next";
+import {dummyBlogPosts} from "../../lib/dummy-blog-posts-state";
+
+const BlogPost = ({blogPost}: {blogPost: BlogPostData}) => {
+
+  return (
+    <div>
+      <Head>
+        <title>Blog Detail</title>
+        <meta name="description" content="Blog Detail" />
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      <main>
+        <PaddingXWrapper className="pt-8">
+          <SimpleHeadlineAndTitleSection headline={blogPost.header}>
+            <div></div>
+          </SimpleHeadlineAndTitleSection>
+        </PaddingXWrapper>
+      </main>
+    </div>
+  );
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: (await fetchBlogPosts()).map(blogPost => ({ params: { slug: blogPost.id  }})),
+    fallback: false, // can also be true or 'blocking'
+  }
+}
+export const getStaticProps: GetStaticProps = async (context) => {
+  const blogPost = (await fetchBlogPosts()).filter(item => item.id === ((context.params as any).slug))[0];
+  return {
+    props: {
+      blogPost
+    }
+  }
+}
+
+const fetchBlogPosts = async () => {
+  return dummyBlogPosts;
+}
+
+export default BlogPost

--- a/frontend/pages/blog/[slug].tsx
+++ b/frontend/pages/blog/[slug].tsx
@@ -1,12 +1,11 @@
 import Head from "next/head";
 import PaddingXWrapper from "../../components/padding-x-wrapper";
 import SimpleHeadlineAndTitleSection from "../../components/simple-headline-and-title-section";
-import {BlogPost as BlogPostData} from "../../components/blog-list";
-import {GetStaticPaths, GetStaticProps} from "next";
-import {dummyBlogPosts} from "../../lib/dummy-blog-posts-state";
+import { BlogPost as BlogPostData } from "../../components/blog-list";
+import { GetStaticPaths, GetStaticProps } from "next";
+import { dummyBlogPosts } from "../../lib/dummy-blog-posts-state";
 
-const BlogPost = ({blogPost}: {blogPost: BlogPostData}) => {
-
+const BlogPost = ({ blogPost }: { blogPost: BlogPostData }) => {
   return (
     <div>
       <Head>
@@ -23,25 +22,29 @@ const BlogPost = ({blogPost}: {blogPost: BlogPostData}) => {
       </main>
     </div>
   );
-}
+};
 
 export const getStaticPaths: GetStaticPaths = async () => {
   return {
-    paths: (await fetchBlogPosts()).map(blogPost => ({ params: { slug: blogPost.id  }})),
+    paths: (await fetchBlogPosts()).map((blogPost) => ({
+      params: { slug: blogPost.id },
+    })),
     fallback: false, // can also be true or 'blocking'
-  }
-}
+  };
+};
 export const getStaticProps: GetStaticProps = async (context) => {
-  const blogPost = (await fetchBlogPosts()).filter(item => item.id === ((context.params as any).slug))[0];
+  const blogPost = (await fetchBlogPosts()).filter(
+    (item) => item.id === (context.params as any).slug
+  )[0];
   return {
     props: {
-      blogPost
-    }
-  }
-}
+      blogPost,
+    },
+  };
+};
 
 const fetchBlogPosts = async () => {
   return dummyBlogPosts;
-}
+};
 
-export default BlogPost
+export default BlogPost;

--- a/frontend/pages/blog/[slug].tsx
+++ b/frontend/pages/blog/[slug].tsx
@@ -4,6 +4,7 @@ import SimpleHeadlineAndTitleSection from "../../components/simple-headline-and-
 import { BlogPost as BlogPostData } from "../../components/blog-list";
 import { GetStaticPaths, GetStaticProps } from "next";
 import { dummyBlogPosts } from "../../lib/dummy-blog-posts-state";
+import { Text } from "@mantine/core";
 
 const BlogPost = ({ blogPost }: { blogPost: BlogPostData }) => {
   return (
@@ -16,7 +17,10 @@ const BlogPost = ({ blogPost }: { blogPost: BlogPostData }) => {
       <main>
         <PaddingXWrapper className="pt-8">
           <SimpleHeadlineAndTitleSection headline={blogPost.header}>
-            <div></div>
+            <Text className="mt-4 text-md font-bold text-m_dark-2">
+              {blogPost.date}
+            </Text>
+            <Text className="mt-4 text-lg">{blogPost.description}</Text>
           </SimpleHeadlineAndTitleSection>
         </PaddingXWrapper>
       </main>


### PR DESCRIPTION
* SSGとした
* そのため、ブログデータを固定化する必要があり、毎回ランダムで作成していたダミーstateを、固定のブログデータに変更
* ブログリストページはstatic + client fetchのままにしつつ、blog detailに飛べるようにリンク化（とりあえずヘッダをリンクとした）